### PR TITLE
http: make request with contexx

### DIFF
--- a/http.go
+++ b/http.go
@@ -192,20 +192,20 @@ var bufferPool = sync.Pool{
 	New: func() interface{} { return new(bytes.Buffer) },
 }
 
-func (h *httpGetter) Get(context context.Context, in *pb.GetRequest, out *pb.GetResponse) error {
+func (h *httpGetter) Get(ctx context.Context, in *pb.GetRequest, out *pb.GetResponse) error {
 	u := fmt.Sprintf(
 		"%v%v/%v",
 		h.baseURL,
 		url.QueryEscape(in.GetGroup()),
 		url.QueryEscape(in.GetKey()),
 	)
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return err
 	}
 	tr := http.DefaultTransport
 	if h.transport != nil {
-		tr = h.transport(context)
+		tr = h.transport(ctx)
 	}
 	res, err := tr.RoundTrip(req)
 	if err != nil {

--- a/http_test.go
+++ b/http_test.go
@@ -93,7 +93,7 @@ func TestHTTPPool(t *testing.T) {
 
 	for _, key := range testKeys(nGets) {
 		var value string
-		if err := g.Get(nil, key, StringSink(&value)); err != nil {
+		if err := g.Get(context.TODO(), key, StringSink(&value)); err != nil {
 			t.Fatal(err)
 		}
 		if suffix := ":" + key; !strings.HasSuffix(value, suffix) {

--- a/peers.go
+++ b/peers.go
@@ -26,7 +26,7 @@ import (
 
 // ProtoGetter is the interface that must be implemented by a peer.
 type ProtoGetter interface {
-	Get(context context.Context, in *pb.GetRequest, out *pb.GetResponse) error
+	Get(ctx context.Context, in *pb.GetRequest, out *pb.GetResponse) error
 }
 
 // PeerPicker is the interface that must be implemented to locate


### PR DESCRIPTION
- use ctx naming convention
- use context.TODO() instead of nil

Signed-off-by: Bobby DeSimone <bobbydesimone@gmail.com>